### PR TITLE
Ansible Playbook for Configuring HTTPD inside Docker

### DIFF
--- a/Ansible Httpd Docker/ansible.cfg
+++ b/Ansible Httpd Docker/ansible.cfg
@@ -1,0 +1,12 @@
+[defaults]
+inventory = /home/ec2-user/ansible/inventory
+roles_path = ~/.ansible/collections:/usr/share/ansible/roles:/home/ec2-user/ansible/roles
+collections_path = ~/.ansible/roles:/usr/share/ansible/roles:/home/ec2-user/ansible/mycollection
+ask_pass = false
+host_key_checking = false
+
+[privilege_escalation]
+become = true
+become_method = sudo
+become_user = root
+become_ask_pass = false

--- a/Ansible Httpd Docker/docker_playbook.yml
+++ b/Ansible Httpd Docker/docker_playbook.yml
@@ -1,0 +1,54 @@
+---
+- name: Configure and Run Docker Container
+  hosts: dev  # Use the group name from your inventory file
+  remote_user: ec2-user  # SSH username for connecting to the EC2 instance
+  become: yes
+  become_method: sudo
+  tasks:
+    - name: Install Docker on Amazon Linux 2
+      ansible.builtin.package:
+        name: docker
+        state: present
+
+    - name: Start and enable Docker service
+      ansible.builtin.service:
+        name: docker
+        state: started
+        enabled: yes
+
+    - name: Pull the httpd server image from Docker Hub
+      community.docker.docker_image:
+        name: httpd:latest
+        source: pull
+
+    - name: Create /var/www/html directory
+      ansible.builtin.file:
+        path: /var/www/html
+        state: directory
+
+    - name: Create an HTML file
+      ansible.builtin.copy:
+        content: "<html><body><h1>Hello, Azfar this side from Arth3. 0</h1></body></html>"
+        dest: /var/www/html/index.html
+
+    - name: Remove the existing container if it exists
+      community.docker.docker_container:
+        name: my_httpd_container
+        state: absent
+      ignore_errors: yes
+
+    - name: Run the Docker container
+      community.docker.docker_container:
+        name: my_httpd_container
+        image: httpd:latest
+        ports:
+          - "8080:80"
+        volumes:
+          - /var/www/html:/usr/local/apache2/htdocs/
+        state: started
+
+  handlers:
+    - name: Reload Apache
+      ansible.builtin.service:
+        name: httpd
+        state: reloaded

--- a/Ansible Httpd Docker/index.html
+++ b/Ansible Httpd Docker/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Apache Web Server</title>
+    <style>
+        /* Global styles */
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #dc31e8;
+            text-align: center;
+        }
+
+        /* Header styles */
+        header {
+            background-color: #00FFFF;
+            color: #333;
+            padding: 20px;
+            border-bottom: 5px solid #333;
+        }
+
+        h1 {
+            font-size: 36px;
+            margin: 0;
+        }
+
+        /* Content styles */
+        .content {
+            padding: 20px;
+        }
+
+        p {
+            font-size: 18px;
+            color: #666;
+            line-height: 1.6;
+        }
+
+        /* Image styles */
+        img {
+            max-width: 100%;
+            height: auto;
+            border: 5px solid #fff;
+            border-radius: 10px;
+        }
+
+        /* Link styles */
+        a {
+            color: #101516;
+            text-decoration: none;
+            font-weight: bold;
+        }
+
+        a:hover {
+            color: #FFFFFF;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Welcome to the Apache Web Server!</h1>
+    </header>
+    <div class="content">
+            <h1><p><span style="font-weight: bold; font-size: 1.2em;  color: black;"> <a href="https://www.linkedin.com/in/mayank-sharma-devops">  This is Mayank Sharma of Arth team 18 and this is a project of ansible playbook</a></span></p></h1>
+          <p>For more information, visit the <a href="https://www.linkedin.com/posts/mayank-sharma-devops_linkedintechcommunity-dockerwebservermagic-activity-7093840628077268993-xL-S?utm_source=share&utm_medium=member_desktop">Apache HTTP Server Project</a>.</p>
+          <!-- Inserting the Apache web server image -->
+          <img src="https://ubunlog.com/wp-content/uploads/2022/03/Apache-1024x483.jpg" alt="Apache Web Server">
+   </div>
+</body>
+</html>

--- a/Ansible Httpd Docker/inventory
+++ b/Ansible Httpd Docker/inventory
@@ -1,0 +1,2 @@
+[dev]
+host IP # replace ip of your slave node

--- a/Ansible Httpd Docker/readme.md
+++ b/Ansible Httpd Docker/readme.md
@@ -1,0 +1,135 @@
+# Ansible Playbook for Configuring HTTPD inside Docker
+
+This repository contains an Ansible playbook to configure an HTTPD (Apache) server inside a Docker container. Follow the steps below to set up and run the playbook.
+
+## Steps
+
+### 1. Install Ansible
+Install Ansible on your master node:
+```sh
+sudo yum install ansible-core -y
+```
+
+### 2. Create an Ansible Directory
+Create a directory for your Ansible configuration and navigate into it:
+```sh
+mkdir ansible
+cd ansible
+```
+
+### 3. Configuration with ansible.cfg
+Create the Ansible configuration file:
+
+```sh
+vim ansible.cfg
+```
+Paste the following content into `ansible.cfg`:
+
+```sh
+[defaults]
+inventory = inventory
+```
+
+### 4. Create an Inventory File
+Create an inventory file and add the IP address of your `slave node`:
+
+```sh
+vim inventory
+[webservers]
+<slave_node_ip> ansible_connection=ssh ansible_user=<your_user>
+```
+
+### 5. Establish Password Access
+Ensure passwordless SSH access from the master node to the slave node. You can do this by copying the `SSH` key:
+
+```sh
+ssh-copy-id <your_user>@<slave_node_ip>
+```
+
+### 6. Verify Connectivity
+Verify that the Ansible master node can connect to the slave node:
+
+```sh
+ansible all -m ping
+```
+
+### 7. Create the Playbook File
+Create the playbook file docker.yml:
+
+```sh
+vim docker.yml
+```
+Paste the following content into `docker-playbook.yml`:
+
+```sh
+---
+- name: Configure and Run Docker Container
+  hosts: dev  # Use the group name from your inventory file
+  remote_user: ec2-user  # SSH username for connecting to the EC2 instance
+  become: yes
+  become_method: sudo
+  tasks:
+    - name: Install Docker on Amazon Linux 2
+      ansible.builtin.package:
+        name: docker
+        state: present
+
+    - name: Start and enable Docker service
+      ansible.builtin.service:
+        name: docker
+        state: started
+        enabled: yes
+
+    - name: Pull the httpd server image from Docker Hub
+      community.docker.docker_image:
+        name: httpd:latest
+        source: pull
+
+    - name: Create /var/www/html directory
+      ansible.builtin.file:
+        path: /var/www/html
+        state: directory
+
+    - name: Create an HTML file
+      ansible.builtin.copy:
+        content: "<html><body><h1>Hello, Azfar this side from Arth3. 0</h1></body></html>"
+        dest: /var/www/html/index.html
+
+    - name: Remove the existing container if it exists
+      community.docker.docker_container:
+        name: my_httpd_container
+        state: absent
+      ignore_errors: yes
+
+    - name: Run the Docker container
+      community.docker.docker_container:
+        name: my_httpd_container
+        image: httpd:latest
+        ports:
+          - "8080:80"
+        volumes:
+          - /var/www/html:/usr/local/apache2/htdocs/
+        state: started
+
+  handlers:
+    - name: Reload Apache
+      ansible.builtin.service:
+        name: httpd
+        state: reloaded
+```
+
+### 8. Validate the Playbook
+Validate your playbook to ensure there are no errors:
+
+```sh
+ansible-playbook --syntax-check docker.yml
+```
+
+### 9. Run the Playbook
+
+```sh
+ansible-playbook docker-playbook.yml
+```
+
+
+

--- a/Ansible Httpd Docker/readme.md
+++ b/Ansible Httpd Docker/readme.md
@@ -1,6 +1,12 @@
 # Ansible Playbook for Configuring HTTPD inside Docker
 
-This repository contains an Ansible playbook to configure an HTTPD (Apache) server inside a Docker container. Follow the steps below to set up and run the playbook.
+This repository contains an Ansible playbook to set up an HTTPD (Apache) server inside a Docker container. By following the steps in this guide, you can easily install and configure the Apache server in a Docker container. The playbook automates everything from installing Docker and HTTPD to configuring the server and running the container.
+
+
+
+https://github.com/mayaworld13/HelpOps-Hub/assets/127987256/15e3429d-9e79-48a5-a98d-14120711402c
+
+
 
 ## Steps
 


### PR DESCRIPTION
Ansible playbook to set up an HTTPD (Apache) server inside a Docker container. By following the steps in this guide, you can easily install and configure the Apache server in a Docker container. The playbook automates everything from installing Docker and HTTPD to configuring the server and running the container.