### PR TITLE
linked about us from resources web page

### DIFF
--- a/website2.0/resources.html
+++ b/website2.0/resources.html
@@ -35,7 +35,7 @@
         </a>
             <ul class="nav-links">
                 <li><a href="index.html">Home</a></li>
-                <li><a href="#">About</a></li>
+                <li><a href="abouts.html">About</a></li>
                 <li><a href="contributor.html">Team</a></li>
                 <li><a href="#">Contact</a></li>
             </ul>


### PR DESCRIPTION
fixes #362 
linked the about us web page from resources web page which was previously not linked . When we click on about us from resource web page it gets linked to it appropriate page .

https://github.com/mdazfar2/HelpOps-Hub/assets/159682348/10b198f2-c9b7-4a3b-891a-93868a93433d

