### PR TITLE
fixed-linking-of-about-us -and -contact-us-from-resources-web-page

### DIFF
--- a/website2.0/resources.html
+++ b/website2.0/resources.html
@@ -35,9 +35,9 @@
         </a>
             <ul class="nav-links">
                 <li><a href="index.html">Home</a></li>
-                <li><a href="#">About</a></li>
+                <li><a href="abouts.html">About</a></li>
                 <li><a href="contributor.html">Team</a></li>
-                <li><a href="#">Contact</a></li>
+                <li><a href="contactus.html">Contact</a></li>
             </ul>
             <!-- <div id="search"><i class="fa fa-search"></i></div> -->
 <div class="toggle-switch">


### PR DESCRIPTION
fixes #362 
linked the about us and contact us web page from resources web page . when we click on about us and contact us from resources web page it gets linked to its appropriate web page .


https://github.com/mdazfar2/HelpOps-Hub/assets/159682348/cf8562b0-a0de-4764-a690-1de644b87ac9

