### PR TITLE
bug: Added discord link in join us button.

### DIFF
--- a/website2.0/contributor.html
+++ b/website2.0/contributor.html
@@ -507,8 +507,10 @@
             Be a contributor and improve HelpOps-Hub and help fellow developers.
           </p>
         </div>
-        <button class="join-button"> Join us now ->
+        <a href="https://discord.gg/UWTrRhqywt">
+        <button class="join-button"> Join us now &#8594;
         </button>
+        </a>
       </div>
   
       <button id="load-more" style="display: none">See More</button>


### PR DESCRIPTION
Added discord link in join us button
![image](https://github.com/mdazfar2/HelpOps-Hub/assets/125277258/188712e5-5858-451a-a59e-2aeebb82f5d1)
issue #384 solved