### PR TITLE
properly apply dark mode in resources page 

### DIFF
--- a/website2.0/resource-details.css
+++ b/website2.0/resource-details.css
@@ -251,3 +251,25 @@ a:hover {
       font-size: 10px;
     }
   }
+  body.dark-mode #container{
+    background-color: #121212;
+    color: #e0e0e0;
+    background: linear-gradient(180deg, #333 8.1%, #121212 100%);
+}
+
+
+body.dark-mode #container li{ 
+    color: #e0e0e0;
+}
+body.dark-mode #container li p{ 
+    color: #e0e0e0;
+}
+body.dark-mode #container h2{ 
+    color:#e0e0e0;
+}
+body.dark-mode p {
+    color: #e0e0e0;
+}
+body.dark-mode #container h3{ 
+    color:#e0e0e0;
+}


### PR DESCRIPTION
fixes #559 


in all the pages of resources dark mode has been added . Here i have shown in few resources but I have made sure that in all the resources page dark mode is working .

BEFORE :  


https://github.com/mdazfar2/HelpOps-Hub/assets/159682348/c2b1e930-2566-4406-b0bd-274d5b6f68fd



AFTER :  




https://github.com/mdazfar2/HelpOps-Hub/assets/159682348/245f8408-b3e0-4f68-b3c3-636b31acc2a4



