### PR TITLE
Fix/spacing in home page and link resources page with the about and contact us page

### DIFF
--- a/website2.0/index.html
+++ b/website2.0/index.html
@@ -55,6 +55,7 @@
     padding: 20px;
     align-items: center;
     left: 60px;
+    margin-bottom: -180px;
   }
 
   .container1 {

--- a/website2.0/resource-details.html
+++ b/website2.0/resource-details.html
@@ -24,9 +24,9 @@
         </a>
             <ul class="nav-links">
                 <li><a href="index.html">Home</a></li>
-                <li><a href="#">About</a></li>
+                <li><a href="abouts.html">About</a></li>
                 <li><a href="contributor.html">Team</a></li>
-                <li><a href="#">Contact</a></li>
+                <li><a href="contactus.html">Contact</a></li>
             </ul>
             <div class="nav-actions">
                 <a href="https://github.com/sponsors/mdazfar2">

--- a/website2.0/styles.css
+++ b/website2.0/styles.css
@@ -1020,3 +1020,6 @@ opacity: 0px;
     align-items: center;
   }
 }
+#img1{
+  margin-bottom: -250px;
+}


### PR DESCRIPTION
fixex #568 
 

- I have removed the extra space as you can see in the attached image of home page  .

![Screenshot 2024-06-22 113352](https://github.com/mdazfar2/HelpOps-Hub/assets/159682348/843176dc-64d4-4dca-a926-ffb6123200cf)

![Screenshot 2024-06-22 113340](https://github.com/mdazfar2/HelpOps-Hub/assets/159682348/df5ff8a8-0e85-4043-8300-e020edf40655)

- I have linked the resources page with the contact us and about page .

BEFORE :

https://github.com/mdazfar2/HelpOps-Hub/assets/159682348/29187ab5-10a6-499f-bcd9-56dba6b020db

AFTER FIXING : 


https://github.com/mdazfar2/HelpOps-Hub/assets/159682348/4ac8cdec-472d-4b9b-9c26-5462d26741a2

