### PR TITLE
Fixed the gap between the social links in Teams page 

### DIFF
--- a/website3.0/stylesheets/teams.css
+++ b/website3.0/stylesheets/teams.css
@@ -152,6 +152,7 @@ body {
   background-size: cover;
   background-repeat: no-repeat;
   transition: 0.5s;
+  padding-right: 0px !important;
 }
 .team-member:hover {
   transform: scale(1.03);
@@ -223,9 +224,10 @@ body {
   height: 100%;
 }
 .social-links {
-  width: 20%;
-  margin-left: 5px;
+  width: 16%;
   padding: 10px;
+  padding-left: 0px !important;
+  padding-right: 0px !important;
 }
 .social-links-items {
   display: flex;


### PR DESCRIPTION
I have reduced the gap between the image and the social links 

closes : #663 

![Screenshot 2024-06-26 173604](https://github.com/mdazfar2/HelpOps-Hub/assets/118350936/9e498356-f955-4d01-8565-668e251f7a8c)
