### PR TITLE
add hovering effect on menu bar items when screen size is reduced .

### DIFF
--- a/website3.0/stylesheets/header.css
+++ b/website3.0/stylesheets/header.css
@@ -267,3 +267,31 @@ nav {
     height: 270px;
   }
 }
+.nav-links1 li a {
+  text-decoration: none;
+  padding: 10px 15px;
+  font-size: 22px;
+  position: relative;
+}
+
+.nav-links1 li a:hover {
+  text-decoration: underline;
+}
+
+.nav-links1 li a::after {
+  content: "";
+  position: absolute;
+  width: 100%;
+  transform: scaleX(0);
+  height: 3px;
+  bottom: 4px;
+  left: 0;
+  background-color: #ff7d1f;
+  transform-origin: bottom right;
+  transition: transform 0.25s ease-out;
+}
+
+.nav-links1 li a:hover::after {
+  transform: scaleX(1);
+  transform-origin: bottom left;
+}


### PR DESCRIPTION
fixes #664 

- before there was no hovering effect on items of menu bar when screen size was reduced as shown in the video .


https://github.com/mdazfar2/HelpOps-Hub/assets/159682348/030b40a6-62f9-4066-9b90-e3c90bb618ea

- now i have added the hovering effect to all the items in menu bar as per the theme as you can see in the video . 


https://github.com/mdazfar2/HelpOps-Hub/assets/159682348/56d29b69-e455-4b1c-aab4-41e744f0793b






