### PR TITLE
Bug: Fixed icons size in Team's Page and fixed Contact Page Overflow

### DIFF
--- a/website3.0/pages/ContactPage.js
+++ b/website3.0/pages/ContactPage.js
@@ -113,7 +113,7 @@ function ContactPage() {
   };
 
   return (
-    <div className="flex flex-col-reverse items-center justify-center space-x-0 mt-36 p-10 md:flex-row md:space-x-40 md:mt-32">
+    <div className="flex flex-col-reverse items-center justify-center space-x-0 mt-36 p-10 md:flex-row md:space-x-40 md:mt-32 max-sm:scale-75">
       {error && <Popup msg={error} error={`${error === "Thank you! We will connect soon." ? "green1" : "red1"}`} />}
       <div className="mt-10">
         <img src="/rateus.png" className="w-[30rem]" alt="rateus" />

--- a/website3.0/pages/TeamsPage.js
+++ b/website3.0/pages/TeamsPage.js
@@ -421,7 +421,7 @@ function TeamsPage() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <FontAwesomeIcon icon={faHeart} className="social-icon scale-[2.5] text-[#6e6e6e]" />
+                <FontAwesomeIcon icon={faHeart} className="social-icon scale-[2.5] max-[525px]:scale-125 text-[#6e6e6e]" />
               </a>
               <p className="text-[14px] mt-[10px] text-[#000000] font-arial">Sponsor</p>
             </div>
@@ -431,7 +431,7 @@ function TeamsPage() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <FontAwesomeIcon icon={faGithub} className="social-icon scale-[2.5] text-[#6e6e6e]" />
+                <FontAwesomeIcon icon={faGithub} className="social-icon scale-[2.5] max-[525px]:scale-125 text-[#6e6e6e]" />
               </a>
               <p className="text-[14px] mt-[10px] text-[#000000] font-arial">Github</p>
             </div>
@@ -441,7 +441,7 @@ function TeamsPage() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <FontAwesomeIcon icon={faLinkedin} className="social-icon scale-[2.5] text-[#6e6e6e]" />
+                <FontAwesomeIcon icon={faLinkedin} className="social-icon scale-[2.5] max-[525px]:scale-125 text-[#6e6e6e]" />
               </a>
               <p className="text-[14px] mt-[10px] text-[#000000] font-arial">LinkedIn</p>
             </div>
@@ -469,7 +469,7 @@ function TeamsPage() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <FontAwesomeIcon icon={faHeart} className="social-icon scale-[2.5] text-[#6e6e6e]" />
+                <FontAwesomeIcon icon={faHeart} className="social-icon scale-[2.5] max-[525px]:scale-125 text-[#6e6e6e]" />
               </a>
               <p className="text-[14px] mt-[10px] text-[#000000] font-arial">Sponsor</p>
             </div>
@@ -479,7 +479,7 @@ function TeamsPage() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <FontAwesomeIcon icon={faGithub} className="social-icon scale-[2.5] text-[#6e6e6e]" />
+                <FontAwesomeIcon icon={faGithub} className="social-icon scale-[2.5] max-[525px]:scale-125 text-[#6e6e6e]" />
               </a>
               <p className="text-[14px] mt-[10px] text-[#000000] font-arial">Github</p>
             </div>
@@ -489,7 +489,7 @@ function TeamsPage() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <FontAwesomeIcon icon={faLinkedin} className="social-icon scale-[2.5] text-[#6e6e6e]" />
+                <FontAwesomeIcon icon={faLinkedin} className="social-icon scale-[2.5] max-[525px]:scale-125 text-[#6e6e6e]" />
               </a>
               <p className="text-[14px] mt-[10px] text-[#000000] font-arial">LinkedIn</p>
             </div>
@@ -517,7 +517,7 @@ function TeamsPage() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <FontAwesomeIcon icon={faHeart} className="social-icon scale-[2.5] text-[#6e6e6e]" />
+                <FontAwesomeIcon icon={faHeart} className="social-icon scale-[2.5] max-[525px]:scale-125 text-[#6e6e6e]" />
               </a>
               <p className="text-[14px] mt-[10px] text-[#000000] font-arial">Sponsor</p>
             </div>
@@ -527,7 +527,7 @@ function TeamsPage() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <FontAwesomeIcon icon={faGithub} className="social-icon scale-[2.5] text-[#6e6e6e]" />
+                <FontAwesomeIcon icon={faGithub} className="social-icon scale-[2.5] max-[525px]:scale-125 text-[#6e6e6e]" />
               </a>
               <p className="text-[14px] mt-[10px] text-[#000000] font-arial">Github</p>
             </div>
@@ -537,7 +537,7 @@ function TeamsPage() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <FontAwesomeIcon icon={faLinkedin} className="social-icon scale-[2.5] text-[#6e6e6e]" />
+                <FontAwesomeIcon icon={faLinkedin} className="social-icon scale-[2.5] max-[525px]:scale-125 text-[#6e6e6e]" />
               </a>
               <p className="text-[14px] mt-[10px] text-[#000000] font-arial">LinkedIn</p>
             </div>
@@ -565,7 +565,7 @@ function TeamsPage() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <FontAwesomeIcon icon={faHeart} className="social-icon scale-[2.5] text-[#6e6e6e]" />
+                <FontAwesomeIcon icon={faHeart} className="social-icon scale-[2.5] max-[525px]:scale-125 text-[#6e6e6e]" />
               </a>
               <p className="text-[14px] mt-[10px] text-[#000000] font-arial">Sponsor</p>
             </div>
@@ -575,7 +575,7 @@ function TeamsPage() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <FontAwesomeIcon icon={faGithub} className="social-icon scale-[2.5] text-[#6e6e6e]" />
+                <FontAwesomeIcon icon={faGithub} className="social-icon scale-[2.5] max-[525px]:scale-125 text-[#6e6e6e]" />
               </a>
               <p className="text-[14px] mt-[10px] text-[#000000] font-arial">Github</p>
             </div>
@@ -585,7 +585,7 @@ function TeamsPage() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <FontAwesomeIcon icon={faLinkedin} className="social-icon scale-[2.5] text-[#6e6e6e]" />
+                <FontAwesomeIcon icon={faLinkedin} className="social-icon scale-[2.5] max-[525px]:scale-125 text-[#6e6e6e]" />
               </a>
               <p className="text-[14px] mt-[10px] text-[#000000] font-arial">LinkedIn</p>
             </div>


### PR DESCRIPTION
**Description:**

This PR fixes the Icon's size in teams page and fixes the contact form overflow in contact page.

**Changes Done:**

- Fixed Icons Size
- Fixed Contact Overflow

**Screenshots:**

## Before:

![Screenshot (280)](https://github.com/mdazfar2/HelpOps-Hub/assets/72603662/e0ddaf6a-654e-495e-8d0b-bb935d8945bb)

![Screenshot (281)](https://github.com/mdazfar2/HelpOps-Hub/assets/72603662/2c15968f-7eeb-4b97-9750-c64dc8c2cfdd)

## After
![Screenshot (277)](https://github.com/mdazfar2/HelpOps-Hub/assets/72603662/98e4dc34-0c3e-414f-9a75-2ef0f1ca2189)

![Screenshot (278)](https://github.com/mdazfar2/HelpOps-Hub/assets/72603662/769fd7fa-e18d-4ee7-9b0a-1229bbff6483)

**Additional Context:**

N/A