### PR TITLE
Added error message when resource not found

### DIFF
--- a/website3.0/pages/ResourcesPage.js
+++ b/website3.0/pages/ResourcesPage.js
@@ -466,6 +466,10 @@ function ResourcesPage() {
           <div id="error">
             <p>{error}</p>
           </div>
+        ) : filteredData.length === 0 ? (     /* Display message when resouce not found on searching */
+          <div id="not-found">
+              <p className="text-center text-4xl font-bold py-20">Resource not found</p>
+            </div>
         ) : (
           <div id="folders-container" className="flex w-full flex-wrap justify-center m-auto">{displayFolders(filteredData)}</div>
         )}


### PR DESCRIPTION
Fixes #537 

Added message "Resource not found" when user's search do not match any following resources

![image](https://github.com/mdazfar2/HelpOps-Hub/assets/114163734/222792f0-ecb2-4511-ba24-4ba40aeeccb5)
