### PR TITLE
Fixed inconsistencies in the mobile view of blog page

### DIFF
--- a/website3.0/components/blogpage/BlogPost.js
+++ b/website3.0/components/blogpage/BlogPost.js
@@ -1071,7 +1071,7 @@ data-tooltip-content="Reaction"
           alt={blog.title}
           onError={handleError}
           id="image-section"
-          className="w-full h-96 object-cover mb-5 rounded-lg max-md:mt-[30px] max-md:p-[8px]"
+          className="w-full lg:h-96 object-contain mb-5 rounded-lg max-md:mt-[30px] max-md:p-[8px]"
         />}
         <div className="px-10 max-[425px]:px-8">
           <div
@@ -1199,7 +1199,7 @@ data-tooltip-content="Reaction"
           </div>
           <div className="flex gap-[20px] mb-[30px] ">
                            {blog.tags && blog.tags.map(data=>{
-                        return <div className="text-[14px] max-sm:text-[13px] max-[425px]:text-[12px]">{"#"+data}</div>})}
+                        return <div className="text-[14px] break-all max-sm:text-[13px] max-[425px]:text-[12px]">{"#"+data}</div>})}
                           </div>
                           {loading? <div className="flex flex-col gap-1"><Skeleton height={10} width={250}  />
                           <Skeleton height={10} width={300}  />

--- a/website3.0/components/profile/GrowYourReachTab.jsx
+++ b/website3.0/components/profile/GrowYourReachTab.jsx
@@ -83,7 +83,7 @@ const handleFollowClick = (userId) => {
                 <li key={user._id} className={`${theme?"bg-gray-200 text-black":"bg-[#383838] text-white"} py-3 px-2 rounded-xl mb-2 flex justify-between items-center`}>
                   <div className="flex items-center">
                     <img src={user.image1} alt={user.name} className="w-10 h-10 rounded-full inline-block mr-3" />
-                    {user.name}
+                    <div className="hidden md:block">{user.name}</div>
                   </div>
                   <a
                     href={`/profile?id=${user.username}&&isView=true`}


### PR DESCRIPTION
several overflow conditions and image breaking on smaller screens is solved.
closes #1373 

earlier:
![image](https://github.com/user-attachments/assets/33710544-9a11-470c-9b96-6d2eb046e7f6)


Now:

https://github.com/user-attachments/assets/b989eff6-8b21-4b74-a04c-1736f3ed2416

