### PR TITLE
[BUG] PreLoader size is too big in the small devices #1452 is solved

### DIFF
--- a/website3.0/package-lock.json
+++ b/website3.0/package-lock.json
@@ -18,6 +18,7 @@
         "@splidejs/react-splide": "^0.7.12",
         "@splidejs/splide-extension-auto-scroll": "^0.5.3",
         "@splinetool/react-spline": "^4.0.0",
+        "@splinetool/runtime": "^1.9.36",
         "@syncfusion/ej2-react-charts": "^26.2.5",
         "@tsparticles/all": "^3.4.0",
         "@tsparticles/react": "^3.0.0",
@@ -32,6 +33,7 @@
         "email-verifier": "^0.4.1",
         "framer-motion": "^11.3.6",
         "jsonwebtoken": "^9.0.2",
+        "lucide-react": "^0.454.0",
         "mongodb": "^6.7.0",
         "mongoose": "^8.4.4",
         "next": "14.2.12",
@@ -47,6 +49,7 @@
         "react-loading-skeleton": "^3.4.0",
         "react-modal": "^3.16.1",
         "react-quill": "^2.0.0",
+        "react-responsive": "^10.0.0",
         "react-share": "^5.1.0",
         "react-tooltip": "^5.27.1",
         "rellax": "^1.12.1",
@@ -628,10 +631,9 @@
       }
     },
     "node_modules/@splinetool/runtime": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/@splinetool/runtime/-/runtime-1.8.8.tgz",
-      "integrity": "sha512-4z0W9ZhjyOaEDv9lVSk/KBB+r3HQ9VguE70ZpF94srkb7P/NpREWloIRL/cRgyC8jX9q1b1LzNNcZXr37sodqQ==",
-      "peer": true,
+      "version": "1.9.36",
+      "resolved": "https://registry.npmjs.org/@splinetool/runtime/-/runtime-1.9.36.tgz",
+      "integrity": "sha512-4VO5WnpVrxoDxYOiFgdgQjGmY+xk/jvyj1xxAaaydC7dVzucjhrt/BKvSCwdERRhRqZkn5Cg4imIumnLXkslpw==",
       "dependencies": {
         "on-change": "^4.0.0",
         "semver-compare": "^1.0.0"
@@ -2921,6 +2923,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q=="
+    },
     "node_modules/css-to-react-native": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
@@ -3753,6 +3760,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4183,6 +4195,14 @@
         "node": "14 || >=16.14"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.454.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.454.0.tgz",
+      "integrity": "sha512-hw7zMDwykCLnEzgncEEjHeA6+45aeEzRYuKHuyRSOPkhko+J3ySGjGIzu+mmMfDFG1vazHepMaYFYHbTFAZAAQ==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/luxon": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
@@ -4211,6 +4231,14 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/matchmediaquery": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.4.2.tgz",
+      "integrity": "sha512-wrZpoT50ehYOudhDjt/YvUJc6eUzcdFPdmbizfgvswCKNHD1/OBOHYJpHie+HXpu6bSkEGieFMYk6VuutaiRfA==",
+      "dependencies": {
+        "css-mediaquery": "^0.1.2"
       }
     },
     "node_modules/memory-pager": {
@@ -4784,7 +4812,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/on-change/-/on-change-4.0.2.tgz",
       "integrity": "sha512-cMtCyuJmTx/bg2HCpHo3ZLeF7FZnBOapLqZHr2AlLeJ5Ul0Zu2mUJJz051Fdwu/Et2YW04ZD+TtU+gVy0ACNCA==",
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -5343,6 +5370,23 @@
         "react-dom": "^16 || ^17 || ^18"
       }
     },
+    "node_modules/react-responsive": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-10.0.0.tgz",
+      "integrity": "sha512-N6/UiRLGQyGUqrarhBZmrSmHi2FXSD++N5VbSKsBBvWfG0ZV7asvUBluSv5lSzdMyEVjzZ6Y8DL4OHABiztDOg==",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.0",
+        "matchmediaquery": "^0.4.2",
+        "prop-types": "^15.6.1",
+        "shallow-equal": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-share": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/react-share/-/react-share-5.1.0.tgz",
@@ -5647,8 +5691,7 @@
     "node_modules/semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "peer": true
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
@@ -5684,6 +5727,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/shallow-equal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
+      "integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg=="
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",

--- a/website3.0/stylesheets/loader.css
+++ b/website3.0/stylesheets/loader.css
@@ -8,6 +8,7 @@
   margin: -75px 0 0 -75px;
   z-index: 99999;
 }
+
 .loader {
   width: 8em;
   height: 8em;
@@ -38,6 +39,7 @@
 
 /* Animations */
 @keyframes ringA {
+
   from,
   4% {
     stroke-dasharray: 0 660;
@@ -85,6 +87,7 @@
 }
 
 @keyframes ringB {
+
   from,
   12% {
     stroke-dasharray: 0 220;
@@ -178,6 +181,7 @@
 }
 
 @keyframes ringD {
+
   from,
   8% {
     stroke-dasharray: 0 440;
@@ -223,6 +227,7 @@
     stroke-dashoffset: -440;
   }
 }
+
 #loader-wrapper {
   position: fixed;
   top: 0;
@@ -231,9 +236,11 @@
   height: 100%;
   z-index: 1001;
 }
+
 .dark-mode #loader-wrapper .loader-section {
   background: linear-gradient(180deg, #333 8.1%, #121212 100%);
 }
+
 #loader-wrapper .loader-section {
   position: fixed;
   top: 0;
@@ -244,6 +251,7 @@
   -webkit-transform: translateX(0);
   transform: translateX(0);
 }
+
 .dark-mode #loader-wrapper .loader-section {
   background: linear-gradient(180deg, #333 8.1%, #121212 100%);
 }
@@ -282,4 +290,17 @@
   opacity: 0;
   -webkit-transition: all 0.3s ease-out;
   transition: all 0.3s ease-out;
+}
+
+@media (max-width: 768px) {
+  .loaderbox {
+    height: 75px;
+    width: 75px;
+    margin: -37.5px 0 0 -37.5px;
+  }
+
+  .loader {
+    width: 4em;
+    height: 4em;
+  }
 }


### PR DESCRIPTION
## Description
PreLoader size issue is solved 

And also format the css content using Shift+Alt+F , for the content easy readable

<br/>



## Related Issues
fixes #1452 


<br/>


## Screenshots / videos (if applicable)
### Before 
![Screenshot 2024-11-07 140253](https://github.com/user-attachments/assets/1a14c3e2-2b3a-422f-936b-373e0dbf501c)

### After
![Screenshot 2024-11-07 151022](https://github.com/user-attachments/assets/7ace752d-2f13-4273-8028-e648676d956f)

