### PR TITLE
Added: Appropriate Page Titles

### DIFF
--- a/website3.0/src/app/about/layout.js
+++ b/website3.0/src/app/about/layout.js
@@ -1,0 +1,8 @@
+export const metadata = {
+    title: "Helpops-Hub • About",
+    description: "Learn more about Helpops-Hub and the amazing work we do.",
+  };
+  
+  export default function About({ children }) {
+    return <>{children}</>;
+  }

--- a/website3.0/src/app/blogs/layout.js
+++ b/website3.0/src/app/blogs/layout.js
@@ -1,0 +1,8 @@
+export const metadata = {
+    title: "Helpops-Hub • Blogs",
+    description: "Explore insightful blogs and articles on Helpops-Hub.",
+  };
+  
+  export default function blogPage({ children }) {
+    return <>{children}</>;
+  }

--- a/website3.0/src/app/contact/layout.js
+++ b/website3.0/src/app/contact/layout.js
@@ -1,0 +1,9 @@
+export const metadata = {
+    title: "Helpops-Hub • Contact",
+    description: "Get in touch with the Helpops-Hub team for inquiries or support.",
+  };
+  
+  export default function Contact({ children }) {
+    return <>{children}</>;
+  }
+  

--- a/website3.0/src/app/devopsforum/layout.js
+++ b/website3.0/src/app/devopsforum/layout.js
@@ -1,0 +1,9 @@
+export const metadata = {
+    title: "Helpops-Hub • Forum",
+    description: "Join discussions and engage with the community on Helpops-Hub's Forum.",
+  };
+  
+  export default function DevopsForum({ children }) {
+    return <>{children}</>;
+  }
+  

--- a/website3.0/src/app/layout.js
+++ b/website3.0/src/app/layout.js
@@ -10,7 +10,7 @@ import React from "react";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata = {
-  title: "Helpops-Hub",
+  title: "Helpops-Hub • Home",
   description: "Ensuring You Never Get Stuck In DevOps Again!",
   icons: {
     icon: "HelpOps-H Fevicon.webp",

--- a/website3.0/src/app/resources/layout.js
+++ b/website3.0/src/app/resources/layout.js
@@ -1,0 +1,9 @@
+export const metadata = {
+    title: "Helpops-Hub • Resources",
+    description: "Access valuable resources and guides on Helpops-Hub to enhance your knowledge.",
+  };
+  
+  export default function Resource({ children }) {
+    return <>{children}</>;
+  }
+  

--- a/website3.0/src/app/team/layout.js
+++ b/website3.0/src/app/team/layout.js
@@ -1,0 +1,8 @@
+export const metadata = {
+    title: "Helpops-Hub • Team",
+    description: "Meet the talented team behind Helpops-Hub and their contributions.",
+  };
+  
+  export default function Team({ children }) {
+    return <>{children}</>;
+  }


### PR DESCRIPTION
## Description
<!--Please include a brief description of the changes-->
All the pages had the same title: Ezyshop. This did not reflect the purpose of the pages previously. I have updated the Page titles specific to the content on the page as below:
- `Helpops-Hub • Resources` for **Resources** Page

This will help the users navigate to the respective pages and also make the website more readable and accessible and remove any ambiguity from the minds of the user and Contributors while navigating through the web pages.


<br/>



## Related Issues

<!--Cite any related issue(s) this pull request addresses. If none, simply state “None”-->
- Closes #1454 


<br/>


## Screenshots / videos (if applicable)
<!--Attach any relevant screenshots or videos demonstrating the changes-->
