### PR TITLE
[Remove] Hacktoberfest & GSSoC from Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -44,8 +44,6 @@ body:
 
         - label: 'I have read the [Contributing Guidelines](https://github.com/mdazfar2/HelpOps-Hub/blob/main/CONTRIBUTING.md)'
           required: true
-        - label: "I'm a GSSoC'24-Extd contributor"
-        - label: "I'm a Hacktoberfest'24 contributor"
 
         - label: 'I am willing to work on this issue (optional)'
           required: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -38,7 +38,5 @@ body:
       options:
         - label: 'I have read the [Contributing Guidelines](https://github.com/mdazfar2/HelpOps-Hub/blob/main/CONTRIBUTING.md)'
           required: true
-        - label: "I'm a GSSoC'24-Extd contributor"
-        - label: "I'm a Hacktoberfest'24 contributor"
         - label: "Soon, I'll complete it and create a Pull Request."
         - label: "I'm a beginner in DevOps, but I'll try to contribute the best resources with hands-on experience."

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -27,8 +27,6 @@ body:
 
         - label: 'I have read the [Contributing Guidelines](https://github.com/mdazfar2/HelpOps-Hub/blob/main/CONTRIBUTING.md)'
           required: true
-        - label: "I'm a GSSoC'24-Extd contributor"
-        - label: "I'm a Hacktoberfest'24 contributor"
 
         - label: 'I am willing to work on this issue (optional)'
           required: false

--- a/.github/ISSUE_TEMPLATE/project.yml
+++ b/.github/ISSUE_TEMPLATE/project.yml
@@ -33,8 +33,6 @@ body:
 
         - label: 'I have read the [Contributing Guidelines](https://github.com/mdazfar2/HelpOps-Hub/blob/main/CONTRIBUTING.md)'
           required: true
-        - label: "I'm a GSSoC'24-Extd contributor"
-        - label: "I'm a Hacktoberfest'24 contributor"
 
         - label: 'I am willing to work on this issue (optional)'
           required: false


### PR DESCRIPTION
In this PR, I removed the Hacktoberfest & GSSoC labels from the issue template because these programs have ended, so I think there’s no need to keep them. Otherwise, new contributors might wonder if they’re still available, so I decided to remove them.